### PR TITLE
ci: add self-healing weekly autoupdate with Claude fallback

### DIFF
--- a/.github/workflows/autoupdate.yml
+++ b/.github/workflows/autoupdate.yml
@@ -1,7 +1,7 @@
 name: Autoupdate
 on:
   schedule:
-    - cron: "0 1 * * *"
+    - cron: "0 6 * * 1"
   workflow_dispatch:
   workflow_call:
 concurrency:
@@ -10,45 +10,205 @@ concurrency:
 permissions:
   contents: write
   actions: write
+  pull-requests: write
+  issues: write
+env:
+  AUTOUPDATE_BRANCH: chore/autoupdate-${{ github.run_id }}
 jobs:
   update:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
-    outputs:
-      updated: ${{ steps.autoupdate.outputs.updated }}
-      version: ${{ steps.autoupdate.outputs.version }}
+    timeout-minutes: 30
     steps:
-      - name: Сheckout repo
-        id: checkout_repo
-        uses: actions/checkout@v5
+      - name: Checkout repo
+        uses: actions/checkout@v4
         with:
-          path: "tmp"
-          ref: "main"
+          ref: main
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Configure git
+        run: |
+          git config user.email "slavianich@gmail.com"
+          git config user.name "Siarhei Dudko"
+
+      - name: Create autoupdate branch
+        run: |
+          git checkout -b "$AUTOUPDATE_BRANCH"
+          git push -u origin "$AUTOUPDATE_BRANCH"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
       - name: Autoupdate
         id: autoupdate
+        continue-on-error: true
         uses: siarheidudko/autoupdater@v6
         with:
           author-email: "slavianich@gmail.com"
           author-name: "Siarhei Dudko"
-          working-directory: ${{ github.workspace }}/tmp
+          working-directory: ${{ github.workspace }}
           ref: ${{ github.repository }}
-          branch: "main"
+          branch: ${{ env.AUTOUPDATE_BRANCH }}
           builds-and-checks: |
             npm run lint
             npm run build
-            npm run test
+            npm run test:all
           debug: "true"
           ignore-packages: |
             @types/node
             typescript
-  deploy:
-    runs-on: ubuntu-latest
-    needs: update
-    if: needs.update.outputs.updated == 'true'
-    steps:
-      - name: Trigger Build and Deploy Workflow
-        uses: benc-uk/workflow-dispatch@v1
-        with:
-          workflow: build-and-deploy.yml
-          ref: main
-          inputs: '{ "tag": "${{ needs.update.outputs.version }}" }'
+
+      - name: Persist autoupdater work on failure
+        if: steps.autoupdate.outcome == 'failure'
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            git add -A
+            git commit -m "chore(deps): autoupdater partial update"
+          fi
+          git push --force-with-lease origin "HEAD:$AUTOUPDATE_BRANCH" || true
+
+      - name: Fallback baseline update if branch still empty vs main
+        if: steps.autoupdate.outcome == 'failure'
+        run: |
+          git fetch origin main
+          if git diff --quiet origin/main; then
+            npx --yes npm-check-updates -u || true
+            npm install --no-audit --no-fund || true
+            if [ -n "$(git status --porcelain)" ]; then
+              git add -A
+              git commit -m "chore(deps): npm-check-updates baseline (autoupdater fallback)"
+              git push origin "HEAD:$AUTOUPDATE_BRANCH"
+            fi
+          fi
+
+      - name: Ensure labels exist
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh label create autoupdate --color "0e8a16" --description "Automated dependency update PRs" --force || true
+          gh label create needs-claude --color "d4c5f9" --description "Needs Claude GitHub App to fix" --force || true
+
+      - name: Check for diff vs main on remote branch
+        id: diff
+        if: always()
+        run: |
+          git fetch origin main "$AUTOUPDATE_BRANCH"
+          if git diff --quiet "origin/main" "origin/$AUTOUPDATE_BRANCH"; then
+            echo "has_diff=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_diff=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Read package version from branch
+        id: pkg
+        if: steps.diff.outputs.has_diff == 'true'
+        run: |
+          VERSION=$(git show "origin/$AUTOUPDATE_BRANCH:package.json" | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>console.log(JSON.parse(s).version))")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Open PR (autoupdater succeeded)
+        id: pr_success
+        if: |
+          steps.autoupdate.outcome == 'success' &&
+          steps.autoupdate.outputs.updated == 'true' &&
+          steps.diff.outputs.has_diff == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BODY=$(cat <<EOF
+          Automated dependency update.
+
+          - autoupdater outcome: success
+          - target version: v${{ steps.pkg.outputs.version }}
+
+          PR-checks must be green before merge.
+          EOF
+          )
+          PR_URL=$(gh pr create \
+            --base main \
+            --head "$AUTOUPDATE_BRANCH" \
+            --title "chore(deps): autoupdate v${{ steps.pkg.outputs.version }}" \
+            --body "$BODY")
+          echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
+
+      - name: Open draft PR (autoupdater failed)
+        id: pr_failure
+        if: steps.autoupdate.outcome == 'failure' && steps.diff.outputs.has_diff == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          BODY=$(cat <<EOF
+          The dependency autoupdater failed during \`builds-and-checks\`.
+
+          Run log: $RUN_URL
+
+          A Claude session has been dispatched to push fixes onto this branch
+          so the following commands all exit 0:
+
+              npm run lint
+              npm run build
+              npm run test:all
+
+          See **Actions → Claude** for progress. The "PR checks" workflow will
+          re-run on each new commit to confirm a green state before merge.
+          EOF
+          )
+          PR_URL=$(gh pr create \
+            --base main \
+            --head "$AUTOUPDATE_BRANCH" \
+            --title "chore(deps): autoupdate (needs claude fix)" \
+            --body "$BODY" \
+            --draft)
+          echo "pr_url=$PR_URL" >> "$GITHUB_OUTPUT"
+
+      - name: Trigger PR checks (GITHUB_TOKEN can't auto-trigger pull_request)
+        if: steps.pr_success.outputs.pr_url != '' || steps.pr_failure.outputs.pr_url != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run pr-checks.yml --ref "$AUTOUPDATE_BRANCH" || true
+
+      - name: Dispatch Claude to fix the failed autoupdate
+        if: steps.pr_failure.outputs.pr_url != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          gh workflow run claude.yml --ref main \
+            -f branch="$AUTOUPDATE_BRANCH" \
+            -f run_url="$RUN_URL"
+
+      - name: Post info comment on the failure PR
+        if: steps.pr_failure.outputs.pr_url != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ steps.pr_failure.outputs.pr_url }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          COMMENT=$(cat <<EOF
+          Claude has been dispatched to fix this PR. See [Actions → Claude](${{ github.server_url }}/${{ github.repository }}/actions/workflows/claude.yml) for progress.
+
+          Failing autoupdate run: $RUN_URL
+          EOF
+          )
+          gh pr comment "$PR_URL" --body "$COMMENT"
+
+      - name: Add labels to PR
+        if: steps.pr_success.outputs.pr_url != '' || steps.pr_failure.outputs.pr_url != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ steps.pr_success.outputs.pr_url || steps.pr_failure.outputs.pr_url }}
+        run: |
+          if [ "${{ steps.pr_failure.outputs.pr_url }}" != "" ]; then
+            gh pr edit "$PR_URL" --add-label autoupdate --add-label needs-claude || true
+          else
+            gh pr edit "$PR_URL" --add-label autoupdate || true
+          fi
+
+      - name: Cleanup branch when nothing to ship
+        if: always() && steps.diff.outputs.has_diff != 'true'
+        run: |
+          git push origin --delete "$AUTOUPDATE_BRANCH" || true

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -23,12 +23,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:
-      NODE_VERSION: 22
+      NODE_VERSION: 24
     steps:
       - name: Сheckout repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Cache node modules
@@ -59,17 +59,17 @@ jobs:
     needs: build
     strategy:
       matrix:
-        node-version: [20, 22]
+        node-version: [20, 22, 24]
     steps:
       - name: Сheckout repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
       - name: Unarchiving dist directory
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v4
         with:
           name: dist
           path: ${{ github.workspace }}/dist
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
       - name: Cache node modules
@@ -86,23 +86,23 @@ jobs:
       - name: Install dependencies
         run: npm ci
       - name: Run test
-        run: npm run test
+        run: npm run test:all
   deploy:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: [build, test]
     env:
-      NODE_VERSION: 22
+      NODE_VERSION: 24
     steps:
       - name: Сheckout repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
       - name: Unarchiving dist directory
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v4
         with:
           name: dist
           path: ${{ github.workspace }}/dist
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Cache node modules
@@ -138,7 +138,7 @@ jobs:
           prerelease: ${{ !!endsWith(env.RELEASE_VERSION, '-beta') }}
       - name: Set registry npm packages
         if: ${{ !endsWith(env.RELEASE_VERSION, '-beta') }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           registry-url: "https://registry.npmjs.org"
       - name: Update npm to latest version

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,90 @@
+name: Claude
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  issues:
+    types: [opened, assigned]
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch Claude should operate on (used by autoupdate flow)"
+        required: true
+        type: string
+      run_url:
+        description: "URL of the failing autoupdate run, included in the prompt for context"
+        required: false
+        type: string
+concurrency:
+  group: "${{ github.workflow }} @ ${{ github.event.issue.number || github.event.pull_request.number || github.event.inputs.branch }}"
+  cancel-in-progress: false
+jobs:
+  claude:
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.branch || github.ref }}
+          fetch-depth: 1
+
+      - name: Prepare autoupdate-fix prompt
+        if: github.event_name == 'workflow_dispatch'
+        id: prep
+        env:
+          BRANCH: ${{ github.event.inputs.branch }}
+          RUN_URL: ${{ github.event.inputs.run_url }}
+        run: |
+          {
+            echo 'prompt<<PROMPT_EOF'
+            cat <<EOF
+          The dependency autoupdater failed on branch \`$BRANCH\` (run: $RUN_URL).
+
+          Push commits to this branch until ALL THREE of the following exit
+          with code 0 in your local working tree, observed via the Bash tool —
+          not inferred:
+
+              npm run lint
+              npm run build
+              npm run test:all
+
+          Hard rules:
+          - Run those three commands yourself before every push. Do not push
+            if any of them is red.
+          - If \`npm install\` or \`npm ci\` is needed, run it first with
+            \`--no-audit --no-fund\` and confirm exit 0.
+          - Limit edits to compatibility shims (types, renamed exports,
+            breaking-change adjustments, eslint-config tweaks for new rule
+            defaults). Do NOT change product logic.
+          - Do NOT bump the package version.
+          - When all three are green, push and stop. CI's \`PR checks\`
+            workflow will re-verify on the PR.
+
+          See CLAUDE.md in the repo root for the full project conventions.
+          EOF
+            echo PROMPT_EOF
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: ${{ steps.prep.outputs.prompt }}
+          claude_args: |
+            --allowedTools "Edit,Write,MultiEdit,Bash(npm:*),Bash(npx:*),Bash(node:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git fetch:*),Bash(git restore:*),Bash(git checkout:*),Bash(rm:*),Bash(mkdir:*),Bash(cat:*),Bash(ls:*)"

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,0 +1,80 @@
+name: PR checks
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+concurrency:
+  group: "${{ github.workflow }} @ ${{ github.ref }}"
+  cancel-in-progress: true
+permissions:
+  contents: read
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      NODE_VERSION: 24
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: Use Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - name: Cache node modules
+        uses: actions/cache@v4
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+      - name: Install dependencies
+        run: npm ci
+      - name: Run linter
+        run: npm run lint
+      - name: Run builder
+        run: npm run build
+      - name: Archiving dist directory
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: ${{ github.workspace }}/dist
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: build
+    strategy:
+      matrix:
+        node-version: [20, 22, 24]
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: Unarchiving dist directory
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: ${{ github.workspace }}/dist
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Cache node modules
+        uses: actions/cache@v4
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+      - name: Install dependencies
+        run: npm ci
+      - name: Run test
+        run: npm run test:all

--- a/.github/workflows/release-on-version-bump.yml
+++ b/.github/workflows/release-on-version-bump.yml
@@ -1,0 +1,57 @@
+name: Release on version bump
+on:
+  push:
+    branches:
+      - main
+concurrency:
+  group: "${{ github.workflow }} @ ${{ github.ref }}"
+  cancel-in-progress: false
+permissions:
+  contents: write
+  actions: write
+env:
+  RELEASE_WORKFLOW: build-and-deploy.yml
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Detect version bump
+        id: bump
+        run: |
+          CURRENT=$(node -e "console.log(require('./package.json').version)")
+          PREVIOUS=$(git show HEAD~1:package.json 2>/dev/null \
+            | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{try{console.log(JSON.parse(s).version)}catch{console.log('')}})")
+          echo "current=$CURRENT"
+          echo "previous=$PREVIOUS"
+          if [ -n "$CURRENT" ] && [ "$CURRENT" != "$PREVIOUS" ]; then
+            echo "bumped=true" >> "$GITHUB_OUTPUT"
+            echo "tag=v$CURRENT" >> "$GITHUB_OUTPUT"
+          else
+            echo "bumped=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Configure git
+        if: steps.bump.outputs.bumped == 'true'
+        run: |
+          git config user.email "slavianich@gmail.com"
+          git config user.name "Siarhei Dudko"
+
+      - name: Force-recreate tag on main HEAD
+        if: steps.bump.outputs.bumped == 'true'
+        run: |
+          git tag -fa "${{ steps.bump.outputs.tag }}" -m "Release ${{ steps.bump.outputs.tag }}"
+          git push --force origin "${{ steps.bump.outputs.tag }}"
+
+      - name: Dispatch release workflow
+        if: steps.bump.outputs.bumped == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run "$RELEASE_WORKFLOW" --ref main -f tag="${{ steps.bump.outputs.tag }}"

--- a/.npmignore
+++ b/.npmignore
@@ -23,6 +23,7 @@ scripts/
 
 # Documentation (development)
 CHANGELOG.md
+CLAUDE.md
 
 # Test files and artifacts
 test*.js

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,62 @@
+# redux-cluster — instructions for Claude
+
+TypeScript cluster module for Redux that synchronizes Redux stores across cluster processes via IPC and TCP sockets. Published to npm as `redux-cluster`.
+
+## Stack
+
+- TypeScript (`tsc`), targeting CJS + ESM dual build with type declarations.
+- Node `>=16` runtime; CI tests on Node 20, 22 and 24.
+- ESLint + Prettier.
+- Test runner: `node --test` with `tsx` import.
+
+## Commands you must know
+
+```bash
+npm run lint           # ESLint over src/**/*.ts and tests/**/*.ts — must exit 0
+npm run build          # Clean + tsc types + tsc ESM + tsc CJS + create-package-files.sh
+npm run test:all       # Aggregator: unit + error + transport (used by autoupdate verification)
+npm run test:unit      # Unit tests only
+npm run test:transport # Transport-layer tests
+npm run test:cluster   # Cluster tests (more setup-heavy)
+npm run test:integration # Integration tests
+npm run test:error     # Error-path tests
+npm test               # Alias for npm run test:all
+```
+
+## Definition of "done" for any change you make
+
+You are NOT done with a code change until **all three** of the following exit 0 in the working tree on the branch you're going to push:
+
+```bash
+npm run lint
+npm run build
+npm run test:all
+```
+
+Run these explicitly with the `Bash` tool before your last commit on the branch. Do not assume "the change looks right" is sufficient — `tsc` errors and ESLint errors must be observed as exit code 0, not inferred. If any of them fail, fix the failure and re-run all three from a clean state until they all pass. Only then commit and push.
+
+If `npm install` is needed (e.g. lockfile changed), run it with `--no-audit --no-fund` and ensure it returned 0 before running checks.
+
+## Boundaries
+
+- Do not modify product logic when fixing dependency-compatibility issues. Acceptable edits: type adjustments, renamed exports, breaking-change shims, ESLint-config tweaks for new rule defaults.
+- Do not bump the package `version` manually. Versioning is handled by the autoupdate flow / maintainer on release.
+- Do not edit `.github/workflows/build-and-deploy.yml` unless explicitly asked — it is the release pipeline.
+- Do not push to `main` directly. Always work on the existing branch you were summoned to.
+
+## When you are working on an autoupdate PR
+
+- Branch will be `chore/autoupdate-<run_id>`.
+- Goal: bring `npm run lint && npm run build && npm run test:all` to green.
+- Push compatibility fixes onto this branch. Each push re-runs `pr-checks.yml` automatically; you don't need to mention checks back to the maintainer until they're green.
+- If a fix is impossible without changing product behavior, stop and leave a comment explaining what's blocked rather than guessing.
+
+## CI quirks specific to this repo
+
+This repo follows the unified `autoupdate-with-claude` baseline (same template across siblings). Several workarounds are intentional:
+- `autoupdate.yml` uses `GITHUB_TOKEN` and explicitly dispatches `pr-checks.yml` after PR creation, because events created via `GITHUB_TOKEN` don't trigger `pull_request` workflows.
+- `autoupdate.yml` dispatches `claude.yml` directly via `workflow_dispatch` (passing `branch` and `run_url` inputs) instead of relying on an `@claude` PR comment.
+- Releases are wired via `release-on-version-bump.yml` (push to main → detect `package.json` version change → force-recreate `vX.Y.Z` tag on main HEAD → dispatch `build-and-deploy.yml`).
+- All actions pinned to the `@v4` line because the runner image currently lacks `externals/node24`, breaking post-cleanup of `@v5/@v6` actions.
+
+Do **not** "fix" any of the above by replacing dispatch calls with comment-based mentions, or by bumping action versions back to `@v5/@v6`.


### PR DESCRIPTION
## Summary

Adds the unified `autoupdate-with-claude` flow already running on `dudko-dev/protoobject` and `siarheidudko/objectstream`. Replaces the existing daily push-to-main `Autoupdate` workflow with a weekly PR-based flow that opens a draft PR + dispatches Claude on failure.

### Files

- **`.github/workflows/autoupdate.yml`** — weekly cron + manual dispatch + Claude fallback. Replaces the prior workflow.
- **`.github/workflows/pr-checks.yml`** — new. lint+build (Node 24) + test:all on Node 20/22/24. Exposes `workflow_dispatch` so autoupdate can chain to it.
- **`.github/workflows/claude.yml`** — new. `anthropics/claude-code-action@v1` with `workflow_dispatch` trigger and prep-prompt step covering autoupdate-fix instructions.
- **`.github/workflows/release-on-version-bump.yml`** — new. On push to main, detects `package.json` version change, force-recreates `vX.Y.Z` tag on main HEAD, dispatches `build-and-deploy.yml`. Replaces the deploy-on-success step that the old `autoupdate.yml` did inline.
- **`.github/workflows/build-and-deploy.yml`** — updated. Default Node 22 → 24, matrix `[20, 22]` → `[20, 22, 24]`, action versions `@v5/@v6` → `@v4` (runner externals quirk).
- **`CLAUDE.md`** — new. Strict definition-of-done for future Claude sessions.
- **`.npmignore`** — `CLAUDE.md` added.

### Configuration

- `builds-and-checks`: `npm run lint` + `npm run build` + `npm run test:all`.
- No `TOKEN_FOR_WORKFLOW`; flow uses `GITHUB_TOKEN` + `workflow_dispatch` chain (same as objectstream).
- Test matrix: Node 20, 22, 24 (was 20, 22).

### Prereqs (verify before merge)

- [ ] Claude GitHub App installed on this repo
- [ ] Secret `CLAUDE_CODE_OAUTH_TOKEN` present

### Test plan

- [ ] PR-checks green on this PR (only workflow files added/modified; existing source unchanged).
- [ ] After merge: Actions → Autoupdate → Run workflow. Verify clean no-op run (no version change in this PR), branch lifecycle managed correctly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZFzpa3MNzjh4kXkF3oLWV)_