### PR TITLE
ci(claude): allow_bots: "*" so autoupdate can dispatch claude.yml

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -85,6 +85,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: "*"
           prompt: ${{ steps.prep.outputs.prompt }}
           claude_args: |
             --allowedTools "Edit,Write,MultiEdit,Bash(npm:*),Bash(npx:*),Bash(node:*),Bash(git status:*),Bash(git diff:*),Bash(git log:*),Bash(git fetch:*),Bash(git restore:*),Bash(git checkout:*),Bash(rm:*),Bash(mkdir:*),Bash(cat:*),Bash(ls:*)"


### PR DESCRIPTION
Same fix as siblings — `allowed_bots: "*"` so dispatched claude.yml runs aren't rejected as Bot actor.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZFzpa3MNzjh4kXkF3oLWV)_